### PR TITLE
[wip] Rewrite Array#minmax with Ruby

### DIFF
--- a/array.c
+++ b/array.c
@@ -5884,26 +5884,6 @@ rb_ary_min(int argc, VALUE *argv, VALUE ary)
     return result;
 }
 
-/*
- *  call-seq:
- *    array.minmax -> [min_val, max_val]
- *    array.minmax {|a, b| ... } -> [min_val, max_val]
- *
- *  Returns a new 2-element \Array containing the minimum and maximum values
- *  from +self+, either per method <tt><=></tt> or per a given block:.
- *
- *  When no block is given, each element in +self+ must respond to method <tt><=></tt>
- *  with an \Integer;
- *  returns a new 2-element \Array containing the minimum and maximum values
- *  from +self+, per method <tt><=></tt>:
- *    [0, 1, 2].minmax # => [0, 2]
- *
- *  When a block is given, the block must return an \Integer;
- *  the block is called <tt>self.size-1</tt> times to compare elements;
- *  returns a new 2-element \Array containing the minimum and maximum values
- *  from +self+, per the block:
- *    ['0', '00', '000'].minmax {|a, b| a.size <=> b.size } # => ["0", "000"]
- */
 static VALUE
 rb_ary_minmax(VALUE ary)
 {
@@ -8171,7 +8151,6 @@ Init_Array(void)
 
     rb_define_method(rb_cArray, "max", rb_ary_max, -1);
     rb_define_method(rb_cArray, "min", rb_ary_min, -1);
-    rb_define_method(rb_cArray, "minmax", rb_ary_minmax, 0);
 
     rb_define_method(rb_cArray, "uniq", rb_ary_uniq, 0);
     rb_define_method(rb_cArray, "uniq!", rb_ary_uniq_bang, 0);

--- a/array.rb
+++ b/array.rb
@@ -58,4 +58,27 @@ class Array
   def sample(n = (ary = false), random: Random)
     Primitive.rb_ary_sample(random, n, ary)
   end
+
+  # call-seq:
+  #    array.minmax -> [min_val, max_val]
+  #    array.minmax {|a, b| ... } -> [min_val, max_val]
+  #
+  # Returns a new 2-element \Array containing the minimum and maximum values
+  # from +self+, either per method <tt><=></tt> or per a given block:.
+  #
+  # When no block is given, each element in +self+ must respond to method <tt><=></tt>
+  # with an \Integer;
+  # returns a new 2-element \Array containing the minimum and maximum values
+  # from +self+, per method <tt><=></tt>:
+  #    [0, 1, 2].minmax # => [0, 2]
+  #
+  # When a block is given, the block must return an \Integer;
+  # the block is called <tt>self.size-1</tt> times to compare elements;
+  # returns a new 2-element \Array containing the minimum and maximum values
+  # from +self+, per the block:
+  #    ['0', '00', '000'].minmax {|a, b| a.size <=> b.size } # => ["0", "000"]
+  def minmax()
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'rb_ary_minmax(self)'
+  end
 end

--- a/benchmark/array_minmax.yml
+++ b/benchmark/array_minmax.yml
@@ -1,0 +1,31 @@
+prelude: |
+  ary2 = 2.times.to_a.shuffle
+  ary10 = 10.times.to_a.shuffle
+  ary100 = 100.times.to_a.shuffle
+  ary500 = 500.times.to_a.shuffle
+  ary1000 = 1000.times.to_a.shuffle
+  ary2000 = 2500.times.to_a.shuffle
+  ary3000 = 2500.times.to_a.shuffle
+  ary5000 = 5000.times.to_a.shuffle
+  ary10000 = 10000.times.to_a.shuffle
+  ary20000 = 20000.times.to_a.shuffle
+  ary50000 = 50000.times.to_a.shuffle
+  ary100000 = 100000.times.to_a.shuffle
+  ary1000000 = 1000000.times.to_a.shuffle
+
+benchmark:
+  ary2.minmax: ary2.minmax
+  ary10.minmax: ary10.minmax
+  ary100.minmax: ary100.minmax
+  ary500.minmax: ary500.minmax
+  ary1000.minmax: ary1000.minmax
+  ary2000.minmax: ary2000.minmax
+  ary3000.minmax: ary3000.minmax
+  ary5000.minmax: ary5000.minmax
+  ary10000.minmax: ary10000.minmax
+  ary20000.minmax: ary20000.minmax
+  ary50000.minmax: ary50000.minmax
+  ary100000.minmax: ary100000.minmax
+  ary1000000.minmax: ary1000000.minmax
+
+loop_count: 10000


### PR DESCRIPTION
### Check performance

- Almost same speed.
- I've run some times, also same as this result.

- $ benchmark-driver -v --rbenv 'master; after' benchmark/array_minmax.yml

```
master: ruby 3.1.0dev (2021-01-10T21:21:10Z master d8c8b79d24) [x86_64-darwin19]
 after: ruby 3.1.0dev (2021-01-10T21:21:10Z master d8c8b79d24)igaiga [x86_64-darwin19]
Calculating -------------------------------------
                         master       after 
         ary2.minmax     1.561M      1.717M i/s -     10.000k times in 0.006408s 0.005823s
        ary10.minmax     1.646M      1.521M i/s -     10.000k times in 0.006074s 0.006576s
       ary100.minmax     1.493M      1.395M i/s -     10.000k times in 0.006697s 0.007166s
       ary500.minmax   875.810k    829.876k i/s -     10.000k times in 0.011418s 0.012050s
      ary1000.minmax   571.135k    574.383k i/s -     10.000k times in 0.017509s 0.017410s
      ary2000.minmax   287.472k    308.814k i/s -     10.000k times in 0.034786s 0.032382s
      ary3000.minmax   297.965k    288.126k i/s -     10.000k times in 0.033561s 0.034707s
      ary5000.minmax   158.448k    160.637k i/s -     10.000k times in 0.063112s 0.062252s
     ary10000.minmax    83.482k     83.711k i/s -     10.000k times in 0.119786s 0.119459s
     ary20000.minmax    41.983k     42.822k i/s -     10.000k times in 0.238193s 0.233523s
     ary50000.minmax    17.204k     17.411k i/s -     10.000k times in 0.581265s 0.574350s
    ary100000.minmax     8.761k      8.846k i/s -     10.000k times in 1.141440s 1.130481s
   ary1000000.minmax    677.163     711.164 i/s -     10.000k times in 14.767495s 14.061454s

Comparison:
                      ary2.minmax
               after:   1717327.8 i/s 
              master:   1560549.3 i/s - 1.10x  slower

                     ary10.minmax
              master:   1646361.5 i/s 
               after:   1520681.3 i/s - 1.08x  slower

                    ary100.minmax
              master:   1493205.9 i/s 
               after:   1395478.6 i/s - 1.07x  slower

                    ary500.minmax
              master:    875810.1 i/s 
               after:    829875.5 i/s - 1.06x  slower

                   ary1000.minmax
               after:    574382.5 i/s 
              master:    571134.8 i/s - 1.01x  slower

                   ary2000.minmax
               after:    308813.5 i/s 
              master:    287472.0 i/s - 1.07x  slower

                   ary3000.minmax
              master:    297964.9 i/s 
               after:    288126.3 i/s - 1.03x  slower

                   ary5000.minmax
               after:    160637.4 i/s 
              master:    158448.5 i/s - 1.01x  slower

                  ary10000.minmax
               after:     83710.7 i/s 
              master:     83482.2 i/s - 1.00x  slower

                  ary20000.minmax
               after:     42822.3 i/s 
              master:     41982.8 i/s - 1.02x  slower

                  ary50000.minmax
               after:     17411.0 i/s 
              master:     17203.9 i/s - 1.01x  slower

                 ary100000.minmax
               after:      8845.8 i/s 
              master:      8760.9 i/s - 1.01x  slower

                ary1000000.minmax
               after:       711.2 i/s 
              master:       677.2 i/s - 1.05x  slower
```

- $ benchmark-driver -v --rbenv 'master; after --jit' benchmark/array_minmax.yml

```
master: ruby 3.1.0dev (2021-01-10T21:21:10Z master d8c8b79d24) [x86_64-darwin19]
 after --jit: ruby 3.1.0dev (2021-01-10T21:21:10Z master d8c8b79d24) +JIT [x86_64-darwin19]
Calculating -------------------------------------
                         master   after --jit 
         ary2.minmax     1.712M        1.696M i/s -     10.000k times in 0.005840s 0.005896s
        ary10.minmax     1.752M        1.706M i/s -     10.000k times in 0.005708s 0.005862s
       ary100.minmax     1.442M        1.471M i/s -     10.000k times in 0.006936s 0.006796s
       ary500.minmax   865.576k      844.595k i/s -     10.000k times in 0.011553s 0.011840s
      ary1000.minmax   591.121k      569.249k i/s -     10.000k times in 0.016917s 0.017567s
      ary2000.minmax   285.144k      277.231k i/s -     10.000k times in 0.035070s 0.036071s
      ary3000.minmax   298.258k      282.000k i/s -     10.000k times in 0.033528s 0.035461s
      ary5000.minmax   160.769k      156.043k i/s -     10.000k times in 0.062201s 0.064085s
     ary10000.minmax    83.234k       77.689k i/s -     10.000k times in 0.120143s 0.128718s
     ary20000.minmax    40.952k       41.493k i/s -     10.000k times in 0.244188s 0.241004s
     ary50000.minmax    17.837k       17.137k i/s -     10.000k times in 0.560627s 0.583534s
    ary100000.minmax     9.222k        8.920k i/s -     10.000k times in 1.084387s 1.121047s
   ary1000000.minmax    653.494       678.048 i/s -     10.000k times in 15.302366s 14.748217s

Comparison:
                      ary2.minmax
              master:   1712328.8 i/s 
         after --jit:   1696065.1 i/s - 1.01x  slower

                     ary10.minmax
              master:   1751927.1 i/s 
         after --jit:   1705902.4 i/s - 1.03x  slower

                    ary100.minmax
         after --jit:   1471453.8 i/s 
              master:   1441753.2 i/s - 1.02x  slower

                    ary500.minmax
              master:    865576.0 i/s 
         after --jit:    844594.6 i/s - 1.02x  slower

                   ary1000.minmax
              master:    591121.4 i/s 
         after --jit:    569249.2 i/s - 1.04x  slower

                   ary2000.minmax
              master:    285144.0 i/s 
         after --jit:    277231.0 i/s - 1.03x  slower

                   ary3000.minmax
              master:    298258.2 i/s 
         after --jit:    281999.9 i/s - 1.06x  slower

                   ary5000.minmax
              master:    160769.1 i/s 
         after --jit:    156042.8 i/s - 1.03x  slower

                  ary10000.minmax
              master:     83234.1 i/s 
         after --jit:     77689.2 i/s - 1.07x  slower

                  ary20000.minmax
         after --jit:     41493.1 i/s 
              master:     40952.1 i/s - 1.01x  slower

                  ary50000.minmax
              master:     17837.2 i/s 
         after --jit:     17137.0 i/s - 1.04x  slower

                 ary100000.minmax
              master:      9221.8 i/s 
         after --jit:      8920.2 i/s - 1.03x  slower

                ary1000000.minmax
         after --jit:       678.0 i/s 
              master:       653.5 i/s - 1.04x  slower
```

### test

- https://github.com/ruby/ruby/blob/v3_0_0/test/ruby/test_array.rb#L1862
